### PR TITLE
Add a test-only end-point to create envelopes.

### DIFF
--- a/app/uk/gov/hmrc/fileupload/frontendGlobal.scala
+++ b/app/uk/gov/hmrc/fileupload/frontendGlobal.scala
@@ -25,6 +25,7 @@ import play.twirl.api.Html
 import uk.gov.hmrc.crypto.ApplicationCrypto
 import uk.gov.hmrc.fileupload.controllers.FileUploadController
 import uk.gov.hmrc.fileupload.infrastructure.DefaultMongoConnection
+import uk.gov.hmrc.fileupload.testonly.TestOnlyController
 import uk.gov.hmrc.play.audit.filters.FrontendAuditFilter
 import uk.gov.hmrc.play.config.{AppName, ControllerConfig, RunMode}
 import uk.gov.hmrc.play.frontend.bootstrap.DefaultFrontendGlobal
@@ -70,9 +71,13 @@ object FrontendGlobal
 
   private val FileUploadControllerClass = classOf[FileUploadController]
 
+  lazy val testOnlyController = new TestOnlyController(ServiceConfig.fileUploadBackendBaseUrl)
+  private val TestOnlyControllerClass = classOf[TestOnlyController]
+
   override def getControllerInstance[A](controllerClass: Class[A]): A = {
     controllerClass match {
       case FileUploadControllerClass => fileUploadController.asInstanceOf[A]
+      case TestOnlyControllerClass => testOnlyController.asInstanceOf[A]
       case _ => super.getControllerInstance(controllerClass)
     }
   }

--- a/app/uk/gov/hmrc/fileupload/testonly/TestOnlyController.scala
+++ b/app/uk/gov/hmrc/fileupload/testonly/TestOnlyController.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.fileupload.testonly
+
+import play.api.Play.current
+import play.api.libs.json.Json
+import play.api.libs.ws.{WS, WSResponse}
+import play.api.mvc.Action
+import play.api.mvc.Results._
+
+import scala.concurrent.ExecutionContext
+
+class TestOnlyController(baseUrl: String)(implicit executionContext: ExecutionContext) {
+
+  def createEnvelope() = Action.async { request =>
+    def extractEnvelopeId(response: WSResponse): String =
+      response
+        .allHeaders
+        .get("Location")
+        .flatMap(_.headOption)
+        .map( l => l.substring(l.lastIndexOf("/") + 1) )
+        .getOrElse("missing/invalid")
+
+    val payload = Json.obj()
+
+    WS.url(s"$baseUrl/file-upload/envelope").post(payload).map { response =>
+      Ok(Json.obj("envelopeId" -> extractEnvelopeId(response)))
+    }
+  }
+
+}

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -11,3 +11,5 @@
 
 # Add all the application routes to the prod.routes file
 ->         /                          prod.Routes
+
+POST        /test-only/create-envelope               @uk.gov.hmrc.fileupload.testonly.TestOnlyController.createEnvelope


### PR DESCRIPTION
Envelopes are meant to be created by another backend microservice on the MDTP.
This test-only end-points allows creating an envelope directly which should
make tests easier.