### PR TITLE
Fix FileUploadISpec to work with new events model

### DIFF
--- a/it/uk/gov/hmrc/fileupload/FileUploadISpec.scala
+++ b/it/uk/gov/hmrc/fileupload/FileUploadISpec.scala
@@ -1,19 +1,15 @@
 package uk.gov.hmrc.fileupload
 
+import org.scalatest.concurrent.Eventually
 import play.api.libs.ws.WS
 import uk.gov.hmrc.fileupload.DomainFixtures._
 import uk.gov.hmrc.fileupload.support.{EnvelopeActions, FileActions, IntegrationSpec}
 import uk.gov.hmrc.fileupload.transfer.{FakeAuditer, FakeFileUploadBackend}
 
-/**
-  * Integration tests for FILE-100
-  * Update FileMetadata
-  *
-  */
-class FileUploadISpec extends IntegrationSpec with FileActions with EnvelopeActions with FakeFileUploadBackend with FakeAuditer {
+class FileUploadISpec extends IntegrationSpec with FileActions with EnvelopeActions with FakeFileUploadBackend with FakeAuditer with Eventually{
 
   feature("File upload front-end") {
-    pending
+
     scenario("transfer a file to the back-end") {
       val fileId = anyFileId
       val envelopeId = anyEnvelopeId
@@ -32,9 +28,13 @@ class FileUploadISpec extends IntegrationSpec with FileActions with EnvelopeActi
 
       result.status should be(200)
 
-      uploadedFile(envelopeId, fileId).map(_.getBodyAsString) shouldBe Some("someTextContents")
-
-      eventQuarantinedTriggered()
+      quarantinedEventTriggered()
+      eventually {
+        fileScannedEventTriggered()
+      }
+      eventually {
+        uploadedFile(envelopeId, fileId).map(_.getBodyAsString) shouldBe Some("someTextContents")
+      }
     }
   }
 }

--- a/it/uk/gov/hmrc/fileupload/FileUploadISpec.scala
+++ b/it/uk/gov/hmrc/fileupload/FileUploadISpec.scala
@@ -15,7 +15,6 @@ class FileUploadISpec extends IntegrationSpec with FileActions with EnvelopeActi
       val envelopeId = anyEnvelopeId
 
       responseToUpload(envelopeId, fileId)
-      stubResponseForSendMetadata(envelopeId, fileId)
       respondToEnvelopeCheck(envelopeId)
 
       val result = WS.url(s"http://localhost:$port/file-upload/upload/envelopes/${envelopeId.value}/files/${fileId.value}")

--- a/it/uk/gov/hmrc/fileupload/FileUploadISpec.scala
+++ b/it/uk/gov/hmrc/fileupload/FileUploadISpec.scala
@@ -6,7 +6,7 @@ import uk.gov.hmrc.fileupload.DomainFixtures._
 import uk.gov.hmrc.fileupload.support.{EnvelopeActions, FileActions, IntegrationSpec}
 import uk.gov.hmrc.fileupload.transfer.{FakeAuditer, FakeFileUploadBackend}
 
-class FileUploadISpec extends IntegrationSpec with FileActions with EnvelopeActions with FakeFileUploadBackend with FakeAuditer with Eventually{
+class FileUploadISpec extends IntegrationSpec with FileActions with EnvelopeActions with FakeFileUploadBackend with FakeAuditer with Eventually {
 
   feature("File upload front-end") {
 

--- a/test/uk/gov/hmrc/fileupload/transfer/FakeFileUploadBackend.scala
+++ b/test/uk/gov/hmrc/fileupload/transfer/FakeFileUploadBackend.scala
@@ -41,6 +41,10 @@ trait FakeFileUploadBackend extends BeforeAndAfterAll with ScalaFutures {
   override def beforeAll() = {
     super.beforeAll()
     backend.start()
+    backend.addStubMapping(
+      post(urlPathMatching("/file-upload/events/*"))
+        .willReturn(aResponse().withStatus(Status.OK))
+        .build())
   }
 
   override def afterAll() = {
@@ -51,7 +55,8 @@ trait FakeFileUploadBackend extends BeforeAndAfterAll with ScalaFutures {
   def respondToEnvelopeCheck(envelopeId: EnvelopeId, status: Int = Status.OK, body: String = "") = {
     backend.addStubMapping(
       get(urlPathMatching(s"/file-upload/envelopes/${envelopeId.value}"))
-        .willReturn(new ResponseDefinitionBuilder()
+        .willReturn(
+          aResponse()
           .withBody(body)
           .withStatus(status))
         .build())
@@ -60,7 +65,8 @@ trait FakeFileUploadBackend extends BeforeAndAfterAll with ScalaFutures {
   def responseToUpload(envelopeId: EnvelopeId, fileId: FileId, status: Int = Status.OK, body: String = "") = {
     backend.addStubMapping(
       put(urlPathMatching(fileContentUrl(envelopeId, fileId)))
-        .willReturn(new ResponseDefinitionBuilder()
+        .willReturn(
+          aResponse()
           .withBody(body)
           .withStatus(status))
         .build())
@@ -69,8 +75,9 @@ trait FakeFileUploadBackend extends BeforeAndAfterAll with ScalaFutures {
   def respondToCreateEnvelope(envelopeIdOfCreated: EnvelopeId) = {
     backend.addStubMapping(
       post(urlPathMatching(s"/file-upload/envelopes"))
-        .willReturn(new ResponseDefinitionBuilder()
-            .withHeader("Location", s"$fileUploadBackendBaseUrl/file-upload/envelopes/${envelopeIdOfCreated.value}")
+        .willReturn(
+          aResponse()
+          .withHeader("Location", s"$fileUploadBackendBaseUrl/file-upload/envelopes/${envelopeIdOfCreated.value}")
           .withStatus(Status.CREATED))
         .build())
   }
@@ -78,7 +85,8 @@ trait FakeFileUploadBackend extends BeforeAndAfterAll with ScalaFutures {
   def responseToDownloadFile(envelopeId: EnvelopeId, fileId: FileId, textBody: String = "", status: Int = Status.OK) = {
     backend.addStubMapping(
       get(urlPathMatching(fileContentUrl(envelopeId, fileId)))
-        .willReturn(new ResponseDefinitionBuilder()
+        .willReturn(
+          aResponse()
           .withBody(textBody)
           .withStatus(status))
         .build())
@@ -100,12 +108,16 @@ trait FakeFileUploadBackend extends BeforeAndAfterAll with ScalaFutures {
     backend.findAll(putRequestedFor(urlPathMatching(fileContentUrl(envelopeId, fileId)))).asScala.headOption
   }
 
-  def eventQuarantinedTriggered() = {
-    backend.verify(postRequestedFor(urlEqualTo("/file-upload/events/Quarantined")))
+  def quarantinedEventTriggered() = {
+    backend.verify(postRequestedFor(urlEqualTo("/file-upload/events/FileInQuarantineStored")))
+  }
+
+  def fileScannedEventTriggered() = {
+    backend.verify(postRequestedFor(urlEqualTo("/file-upload/events/FileScanned")))
   }
 
   private def fileContentUrl(envelopeId: EnvelopeId, fileId: FileId) = {
-    s"/file-upload/envelopes/$envelopeId/files/$fileId/content"
+    s"/file-upload/envelopes/$envelopeId/files/$fileId"
   }
 
   private def metadataContentUrl(envelopId: EnvelopeId, fileId: FileId) = {

--- a/test/uk/gov/hmrc/fileupload/transfer/FakeFileUploadBackend.scala
+++ b/test/uk/gov/hmrc/fileupload/transfer/FakeFileUploadBackend.scala
@@ -92,18 +92,6 @@ trait FakeFileUploadBackend extends BeforeAndAfterAll with ScalaFutures {
         .build())
   }
 
-  def stubResponseForSendMetadata(envelopeId: EnvelopeId, fileId: FileId, metadata: JsObject = Json.obj("foo" -> "bar"),
-                                  status: Int = Status.OK, body: String = "") = {
-    backend.addStubMapping(
-      put(urlMatching(metadataContentUrl(envelopeId, fileId)))
-        .willReturn(
-          new ResponseDefinitionBuilder()
-            .withStatus(status)
-            .withBody(body)
-        ).build()
-    )
-  }
-
   def uploadedFile(envelopeId: EnvelopeId, fileId: FileId): Option[LoggedRequest] = {
     backend.findAll(putRequestedFor(urlPathMatching(fileContentUrl(envelopeId, fileId)))).asScala.headOption
   }


### PR DESCRIPTION
Fix FileUploadISpec to work with new events model and additionally assert on file scanned event.