### PR TITLE
File 294 integration tests

### DIFF
--- a/it/uk/gov/hmrc/fileupload/FileUploadISpec.scala
+++ b/it/uk/gov/hmrc/fileupload/FileUploadISpec.scala
@@ -3,10 +3,8 @@ package uk.gov.hmrc.fileupload
 import org.scalatest.Matchers
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Seconds, Span}
-import play.api.libs.ws.{WS, WSResponse}
 import uk.gov.hmrc.fileupload.DomainFixtures._
-import uk.gov.hmrc.fileupload.support.{EnvelopeActions, FileActions, IntegrationSpec}
-import uk.gov.hmrc.mongo.MongoSpecSupport
+import uk.gov.hmrc.fileupload.support.{ChunksMongoRepository, EnvelopeActions, FileActions, IntegrationSpec}
 
 class FileUploadISpec extends IntegrationSpec with FileActions with EnvelopeActions with Eventually with Matchers {
 
@@ -32,24 +30,33 @@ class FileUploadISpec extends IntegrationSpec with FileActions with EnvelopeActi
       }(PatienceConfig(timeout = Span(30, Seconds)))
     }
 
-    scenario("""prevent uploading if envelope is not in "OPEN" state"""") {
-
-      // Check no chunks exist in mongo related to the closed envelope
-      // upload dummy file
-      // Check 423 response
-      // Check no chunks have been written to mongo
-
+    scenario("""Prevent uploading if envelope is not in "OPEN" state"""") {
       Wiremock.respondToEnvelopeCheck(envelopeId, body = ENVELOPE_CLOSED_RESPONSE)
 
-      val result = uploadDummyFile(envelopeId, fileId)
+      val repository = new ChunksMongoRepository(mongo)
+      repository.removeAll().futureValue
+      def numberOfChunks = repository.findAll().futureValue.size
+      numberOfChunks shouldBe 0
 
+      val result = uploadDummyFile(envelopeId, fileId)
       result.status should be(423)
+      numberOfChunks shouldBe 0
     }
 
+    scenario("""Ensure we continue to allow uploading if envelope is in "OPEN" state"""") {
+      Wiremock.respondToEnvelopeCheck(envelopeId, body = ENVELOPE_OPEN_RESPONSE)
 
+      val repository = new ChunksMongoRepository(mongo)
+      repository.removeAll().futureValue
+      def numberOfChunks = repository.findAll().futureValue.size
+      numberOfChunks shouldBe 0
+
+      val result = uploadDummyFile(envelopeId, fileId)
+      result.status should be(200)
+      numberOfChunks should be > 0
+    }
 
   }
-
 
 }
 

--- a/it/uk/gov/hmrc/fileupload/FileUploadISpec.scala
+++ b/it/uk/gov/hmrc/fileupload/FileUploadISpec.scala
@@ -6,6 +6,7 @@ import org.scalatest.time.{Seconds, Span}
 import play.api.libs.ws.{WS, WSResponse}
 import uk.gov.hmrc.fileupload.DomainFixtures._
 import uk.gov.hmrc.fileupload.support.{EnvelopeActions, FileActions, IntegrationSpec}
+import uk.gov.hmrc.mongo.MongoSpecSupport
 
 class FileUploadISpec extends IntegrationSpec with FileActions with EnvelopeActions with Eventually with Matchers {
 
@@ -15,24 +16,30 @@ class FileUploadISpec extends IntegrationSpec with FileActions with EnvelopeActi
     val envelopeId = anyEnvelopeId
 
     scenario("transfer a file to the back-end") {
-      responseToUpload(envelopeId, fileId)
-      respondToEnvelopeCheck(envelopeId)
+      Wiremock.responseToUpload(envelopeId, fileId)
+      Wiremock.respondToEnvelopeCheck(envelopeId)
 
       val result = uploadDummyFile(envelopeId, fileId)
 
       result.status should be(200)
 
-      quarantinedEventTriggered()
+      Wiremock.quarantinedEventTriggered()
       eventually {
-        fileScannedEventTriggered()
+        Wiremock.fileScannedEventTriggered()
       }(PatienceConfig(timeout = Span(30, Seconds)))
       eventually {
-        uploadedFile(envelopeId, fileId).map(_.getBodyAsString) shouldBe Some("someTextContents")
+        Wiremock.uploadedFile(envelopeId, fileId).map(_.getBodyAsString) shouldBe Some("someTextContents")
       }(PatienceConfig(timeout = Span(30, Seconds)))
     }
 
     scenario("""prevent uploading if envelope is not in "OPEN" state"""") {
-      respondToEnvelopeCheck(envelopeId, body = ENVELOPE_CLOSED_RESPONSE)
+
+      // Check no chunks exist in mongo related to the closed envelope
+      // upload dummy file
+      // Check 423 response
+      // Check no chunks have been written to mongo
+
+      Wiremock.respondToEnvelopeCheck(envelopeId, body = ENVELOPE_CLOSED_RESPONSE)
 
       val result = uploadDummyFile(envelopeId, fileId)
 

--- a/it/uk/gov/hmrc/fileupload/FileUploadISpec.scala
+++ b/it/uk/gov/hmrc/fileupload/FileUploadISpec.scala
@@ -39,15 +39,7 @@ class FileUploadISpec extends IntegrationSpec with FileActions with EnvelopeActi
       result.status should be(423)
     }
 
-    def uploadDummyFile(envelopeId: EnvelopeId, fileId: FileId): WSResponse = {
-      WS.url(s"http://localhost:$port/file-upload/upload/envelopes/$envelopeId/files/$fileId")
-        .withHeaders("Content-Type" -> "multipart/form-data; boundary=---011000010111000001101001",
-          "X-Request-ID" -> "someId",
-          "X-Session-ID" -> "someId",
-          "X-Requested-With" -> "someId")
-        .post("-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"file1\"; filename=\"test.txt\"\r\nContent-Type: text/plain\r\n\r\nsomeTextContents\r\n-----011000010111000001101001--")
-        .futureValue(PatienceConfig(timeout = Span(10, Seconds)))
-    }
+
 
   }
 

--- a/it/uk/gov/hmrc/fileupload/RepositorySpec.scala
+++ b/it/uk/gov/hmrc/fileupload/RepositorySpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.fileupload.transfer
+package uk.gov.hmrc.fileupload
 
 import java.net.HttpURLConnection._
 
@@ -22,6 +22,8 @@ import cats.data.Xor
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Second, Span}
 import uk.gov.hmrc.fileupload.DomainFixtures._
+import uk.gov.hmrc.fileupload.support.{FakeFileUploadBackend, IntegrationSpec}
+import uk.gov.hmrc.fileupload.transfer.Repository
 import uk.gov.hmrc.fileupload.transfer.TransferService.{EnvelopeAvailableServiceError, EnvelopeNotFoundError}
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 

--- a/it/uk/gov/hmrc/fileupload/support/ChunksMongoRepository.scala
+++ b/it/uk/gov/hmrc/fileupload/support/ChunksMongoRepository.scala
@@ -1,0 +1,16 @@
+package uk.gov.hmrc.fileupload.support
+
+import play.api.libs.json.Json
+import reactivemongo.api.{DB, DBMetaCommands}
+import reactivemongo.bson.BSONObjectID
+import uk.gov.hmrc.mongo.ReactiveRepository
+
+case class Chunk(files_id: String)
+
+object Chunk {
+  implicit val format = Json.format[Chunk]
+}
+
+class ChunksMongoRepository(mongo: () => DB with DBMetaCommands)
+    extends ReactiveRepository[Chunk, BSONObjectID](collectionName = "quarantine.chunks", mongo, domainFormat = Chunk.format) {
+}

--- a/it/uk/gov/hmrc/fileupload/support/FakeFileUploadBackend.scala
+++ b/it/uk/gov/hmrc/fileupload/support/FakeFileUploadBackend.scala
@@ -1,30 +1,13 @@
-/*
- * Copyright 2016 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-package uk.gov.hmrc.fileupload.transfer
+package uk.gov.hmrc.fileupload.support
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock._
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration._
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import com.github.tomakehurst.wiremock.verification.LoggedRequest
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, Suite}
 import play.api.http.Status
 import uk.gov.hmrc.fileupload.{EnvelopeId, FileId}
-
 import scala.collection.JavaConverters._
 
 trait FakeFileUploadBackend extends BeforeAndAfterAll with ScalaFutures {
@@ -115,4 +98,3 @@ trait FakeFileUploadBackend extends BeforeAndAfterAll with ScalaFutures {
 
   }
 }
-

--- a/it/uk/gov/hmrc/fileupload/support/FileActions.scala
+++ b/it/uk/gov/hmrc/fileupload/support/FileActions.scala
@@ -1,5 +1,6 @@
 package uk.gov.hmrc.fileupload.support
 
+import org.scalatest.time.{Seconds, Span}
 import play.api.Play.current
 import play.api.libs.ws.{WS, WSResponse}
 import uk.gov.hmrc.fileupload.{EnvelopeId, FileId}
@@ -31,4 +32,14 @@ trait FileActions extends ActionsSupport {
       .url(s"$url/envelopes/$envelopeId/files/$fileId/metadata")
       .get()
       .futureValue
+
+  def uploadDummyFile(envelopeId: EnvelopeId, fileId: FileId): WSResponse = {
+    WS.url(s"$url/upload/envelopes/$envelopeId/files/$fileId")
+      .withHeaders("Content-Type" -> "multipart/form-data; boundary=---011000010111000001101001",
+        "X-Request-ID" -> "someId",
+        "X-Session-ID" -> "someId",
+        "X-Requested-With" -> "someId")
+      .post("-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"file1\"; filename=\"test.txt\"\r\nContent-Type: text/plain\r\n\r\nsomeTextContents\r\n-----011000010111000001101001--")
+      .futureValue(PatienceConfig(timeout = Span(10, Seconds)))
+  }
 }

--- a/it/uk/gov/hmrc/fileupload/support/IntegrationSpec.scala
+++ b/it/uk/gov/hmrc/fileupload/support/IntegrationSpec.scala
@@ -3,7 +3,7 @@ package uk.gov.hmrc.fileupload.support
 import java.net.ServerSocket
 import java.util.UUID
 
-import org.scalatest.FeatureSpec
+import org.scalatest.{BeforeAndAfterEach, FeatureSpec}
 import org.scalatestplus.play.OneServerPerSuite
 import play.api.test.FakeApplication
 import uk.gov.hmrc.clamav.fake.FakeClam
@@ -11,24 +11,25 @@ import uk.gov.hmrc.mongo.MongoSpecSupport
 
 import scala.concurrent.ExecutionContext
 
-trait IntegrationSpec extends FeatureSpec with MongoSpecSupport with OneServerPerSuite with FakeFileUploadBackend {
+trait IntegrationSpec extends FeatureSpec with MongoSpecSupport with OneServerPerSuite with FakeFileUploadBackend with BeforeAndAfterEach {
 
   override lazy val port: Int = 9000
 
   val nextId = () => UUID.randomUUID().toString
 
-  lazy val fakeClamSocket = new ServerSocket(0)
-  lazy val fakeClam = new FakeClam(fakeClamSocket)(ExecutionContext.global)
+  // creating and closing a ServerSocket in order to get a free port
+  val fakeClamSocket = new ServerSocket(0)
+  val socketPort = fakeClamSocket.getLocalPort
+  fakeClamSocket.close()
 
-  override def beforeAll(): Unit = {
-    super.beforeAll()
+  var fakeClam: FakeClam = _
 
+  override def beforeEach(): Unit = {
+    fakeClam = new FakeClam(new ServerSocket(socketPort))(ExecutionContext.global)
     fakeClam.start()
   }
 
-  override def afterAll(): Unit = {
-    super.afterAll()
-
+  override def afterEach(): Unit = {
     fakeClam.stop()
   }
 
@@ -37,7 +38,7 @@ trait IntegrationSpec extends FeatureSpec with MongoSpecSupport with OneServerPe
       additionalConfiguration = Map(
         "auditing.enabled" -> "false",
         "Test.clam.antivirus.host" -> "127.0.0.1",
-        "Test.clam.antivirus.port" -> fakeClamSocket.getLocalPort,
+        "Test.clam.antivirus.port" -> socketPort,
         "microservice.services.file-upload-backend.port" -> backend.port(),
         "mongodb.uri" -> s"mongodb://localhost:27017/$databaseName"
       )

--- a/it/uk/gov/hmrc/fileupload/support/IntegrationSpec.scala
+++ b/it/uk/gov/hmrc/fileupload/support/IntegrationSpec.scala
@@ -7,7 +7,6 @@ import org.scalatest.FeatureSpec
 import org.scalatestplus.play.OneServerPerSuite
 import play.api.test.FakeApplication
 import uk.gov.hmrc.clamav.fake.FakeClam
-import uk.gov.hmrc.fileupload.transfer.FakeFileUploadBackend
 import uk.gov.hmrc.mongo.MongoSpecSupport
 
 import scala.concurrent.ExecutionContext

--- a/it/uk/gov/hmrc/fileupload/support/IntegrationSpec.scala
+++ b/it/uk/gov/hmrc/fileupload/support/IntegrationSpec.scala
@@ -13,14 +13,12 @@ import scala.concurrent.ExecutionContext
 
 trait IntegrationSpec extends FeatureSpec with MongoSpecSupport with OneServerPerSuite with FakeFileUploadBackend {
 
-  implicit val ecIntegrationSpec = ExecutionContext.global
-
   override lazy val port: Int = 9000
 
   val nextId = () => UUID.randomUUID().toString
 
   lazy val fakeClamSocket = new ServerSocket(0)
-  lazy val fakeClam = new FakeClam(fakeClamSocket)
+  lazy val fakeClam = new FakeClam(fakeClamSocket)(ExecutionContext.global)
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/it/uk/gov/hmrc/fileupload/support/IntegrationSpec.scala
+++ b/it/uk/gov/hmrc/fileupload/support/IntegrationSpec.scala
@@ -8,10 +8,11 @@ import org.scalatestplus.play.OneServerPerSuite
 import play.api.test.FakeApplication
 import uk.gov.hmrc.clamav.fake.FakeClam
 import uk.gov.hmrc.fileupload.transfer.FakeFileUploadBackend
+import uk.gov.hmrc.mongo.MongoSpecSupport
 
 import scala.concurrent.ExecutionContext
 
-trait IntegrationSpec extends FeatureSpec with OneServerPerSuite with FakeFileUploadBackend {
+trait IntegrationSpec extends FeatureSpec with MongoSpecSupport with OneServerPerSuite with FakeFileUploadBackend {
 
   implicit val ecIntegrationSpec = ExecutionContext.global
 
@@ -40,7 +41,9 @@ trait IntegrationSpec extends FeatureSpec with OneServerPerSuite with FakeFileUp
         "auditing.enabled" -> "false",
         "Test.clam.antivirus.host" -> "127.0.0.1",
         "Test.clam.antivirus.port" -> fakeClamSocket.getLocalPort,
-        "microservice.services.file-upload-backend.port" -> backend.port()
+        "microservice.services.file-upload-backend.port" -> backend.port(),
+        "mongodb.uri" -> s"mongodb://localhost:27017/$databaseName"
       )
     )
+
 }

--- a/test/uk/gov/hmrc/fileupload/transfer/FakeFileUploadBackend.scala
+++ b/test/uk/gov/hmrc/fileupload/transfer/FakeFileUploadBackend.scala
@@ -51,63 +51,68 @@ trait FakeFileUploadBackend extends BeforeAndAfterAll with ScalaFutures {
   val ENVELOPE_OPEN_RESPONSE = """ { "status" : "OPEN" } """
   val ENVELOPE_CLOSED_RESPONSE = """ { "status" : "CLOSED" } """
 
-  def respondToEnvelopeCheck(envelopeId: EnvelopeId, status: Int = Status.OK, body: String = ENVELOPE_OPEN_RESPONSE) = {
-    backend.addStubMapping(
-      get(urlPathMatching(s"/file-upload/envelopes/${envelopeId.value}"))
-        .willReturn(
-          aResponse()
-          .withBody(body)
-          .withStatus(status))
-        .build())
-  }
+  object Wiremock {
 
-  def responseToUpload(envelopeId: EnvelopeId, fileId: FileId, status: Int = Status.OK, body: String = "") = {
-    backend.addStubMapping(
-      put(urlPathMatching(fileContentUrl(envelopeId, fileId)))
-        .willReturn(
-          aResponse()
-          .withBody(body)
-          .withStatus(status))
-        .build())
-  }
+    def respondToEnvelopeCheck(envelopeId: EnvelopeId, status: Int = Status.OK, body: String = ENVELOPE_OPEN_RESPONSE) = {
+      backend.addStubMapping(
+        get(urlPathMatching(s"/file-upload/envelopes/${ envelopeId.value }"))
+          .willReturn(
+            aResponse()
+              .withBody(body)
+              .withStatus(status))
+          .build())
+    }
 
-  def respondToCreateEnvelope(envelopeIdOfCreated: EnvelopeId) = {
-    backend.addStubMapping(
-      post(urlPathMatching(s"/file-upload/envelopes"))
-        .willReturn(
-          aResponse()
-          .withHeader("Location", s"$fileUploadBackendBaseUrl/file-upload/envelopes/${envelopeIdOfCreated.value}")
-          .withStatus(Status.CREATED))
-        .build())
-  }
+    def responseToUpload(envelopeId: EnvelopeId, fileId: FileId, status: Int = Status.OK, body: String = "") = {
+      backend.addStubMapping(
+        put(urlPathMatching(fileContentUrl(envelopeId, fileId)))
+          .willReturn(
+            aResponse()
+              .withBody(body)
+              .withStatus(status))
+          .build())
+    }
 
-  def responseToDownloadFile(envelopeId: EnvelopeId, fileId: FileId, textBody: String = "", status: Int = Status.OK) = {
-    backend.addStubMapping(
-      get(urlPathMatching(fileContentUrl(envelopeId, fileId)))
-        .willReturn(
-          aResponse()
-          .withBody(textBody)
-          .withStatus(status))
-        .build())
-  }
+    def respondToCreateEnvelope(envelopeIdOfCreated: EnvelopeId) = {
+      backend.addStubMapping(
+        post(urlPathMatching(s"/file-upload/envelopes"))
+          .willReturn(
+            aResponse()
+              .withHeader("Location", s"$fileUploadBackendBaseUrl/file-upload/envelopes/${ envelopeIdOfCreated.value }")
+              .withStatus(Status.CREATED))
+          .build())
+    }
 
-  def uploadedFile(envelopeId: EnvelopeId, fileId: FileId): Option[LoggedRequest] = {
-    backend.findAll(putRequestedFor(urlPathMatching(fileContentUrl(envelopeId, fileId)))).asScala.headOption
-  }
+    def responseToDownloadFile(envelopeId: EnvelopeId, fileId: FileId, textBody: String = "", status: Int = Status.OK) = {
+      backend.addStubMapping(
+        get(urlPathMatching(fileContentUrl(envelopeId, fileId)))
+          .willReturn(
+            aResponse()
+              .withBody(textBody)
+              .withStatus(status))
+          .build())
+    }
 
-  def quarantinedEventTriggered() = {
-    backend.verify(postRequestedFor(urlEqualTo("/file-upload/events/FileInQuarantineStored")))
-  }
+    def uploadedFile(envelopeId: EnvelopeId, fileId: FileId): Option[LoggedRequest] = {
+      backend.findAll(putRequestedFor(urlPathMatching(fileContentUrl(envelopeId, fileId)))).asScala.headOption
+    }
 
-  def fileScannedEventTriggered() = {
-    backend.verify(postRequestedFor(urlEqualTo("/file-upload/events/FileScanned")))
-  }
+    def quarantinedEventTriggered() = {
+      backend.verify(postRequestedFor(urlEqualTo("/file-upload/events/FileInQuarantineStored")))
+    }
 
-  private def fileContentUrl(envelopeId: EnvelopeId, fileId: FileId) = {
-    s"/file-upload/envelopes/$envelopeId/files/$fileId"
-  }
+    def fileScannedEventTriggered() = {
+      backend.verify(postRequestedFor(urlEqualTo("/file-upload/events/FileScanned")))
+    }
 
-  private def metadataContentUrl(envelopId: EnvelopeId, fileId: FileId) = {
-    s"/file-upload/envelopes/$envelopId/files/$fileId/metadata"
+    private def fileContentUrl(envelopeId: EnvelopeId, fileId: FileId) = {
+      s"/file-upload/envelopes/$envelopeId/files/$fileId"
+    }
+
+    private def metadataContentUrl(envelopId: EnvelopeId, fileId: FileId) = {
+      s"/file-upload/envelopes/$envelopId/files/$fileId/metadata"
+    }
+
   }
 }
+

--- a/test/uk/gov/hmrc/fileupload/transfer/RepositorySpec.scala
+++ b/test/uk/gov/hmrc/fileupload/transfer/RepositorySpec.scala
@@ -37,7 +37,7 @@ class RepositorySpec extends UnitSpec with ScalaFutures with WithFakeApplication
     "if the ID is known of return a success" in {
       val envelopeId = anyEnvelopeId
 
-      respondToEnvelopeCheck(envelopeId, HTTP_OK)
+      Wiremock.respondToEnvelopeCheck(envelopeId, HTTP_OK)
 
       envelopeAvailable(envelopeId).futureValue shouldBe Xor.right(envelopeId)
     }
@@ -45,7 +45,7 @@ class RepositorySpec extends UnitSpec with ScalaFutures with WithFakeApplication
     "if the ID is not known of return an error" in {
       val envelopeId = anyEnvelopeId
 
-      respondToEnvelopeCheck(envelopeId, HTTP_NOT_FOUND)
+      Wiremock.respondToEnvelopeCheck(envelopeId, HTTP_NOT_FOUND)
 
       envelopeAvailable(envelopeId).futureValue shouldBe Xor.left(EnvelopeNotFoundError(envelopeId))
     }
@@ -54,7 +54,7 @@ class RepositorySpec extends UnitSpec with ScalaFutures with WithFakeApplication
       val envelopeId = anyEnvelopeId
       val errorBody = "SOME_ERROR"
 
-      respondToEnvelopeCheck(envelopeId, HTTP_INTERNAL_ERROR, errorBody)
+      Wiremock.respondToEnvelopeCheck(envelopeId, HTTP_INTERNAL_ERROR, errorBody)
 
       envelopeAvailable(envelopeId).futureValue shouldBe Xor.left(EnvelopeAvailableServiceError(envelopeId, "SOME_ERROR"))
     }


### PR DESCRIPTION
The earlier intermittent issue appears to have been due to the way in which the FakeClam instance was being started and stopped across tests, resulting in attempted re-use or premature shutdown of the associated sockets. IntegrationSpec has been modified to start and stop FakeClam re-using the same port within each test. The integration tests have been re-run at least 10 times locally.