### PR TITLE
Fixed errorCode url parameter

### DIFF
--- a/app/uk/gov/hmrc/fileupload/controllers/RedirectionFeature.scala
+++ b/app/uk/gov/hmrc/fileupload/controllers/RedirectionFeature.scala
@@ -115,7 +115,7 @@ object RedirectionFeature {
     Results.Redirect(url.url, MOVED_PERMANENTLY)
 
   def addErrorDataToUrl(status: Int, msg: String): ValidatedUrl => ValidatedUrl =
-    baseUrl => ValidatedUrl(baseUrl.url + s"?errorCode:$status&reason=$msg")
+    baseUrl => ValidatedUrl(baseUrl.url + s"?errorCode=$status&reason=$msg")
 
   def extractErrorMsg(result: Result): String = {
     result.body.asInstanceOf[HttpEntity.Strict].data.decodeString("utf-8") // how to do it cleanly?

--- a/test/uk/gov/hmrc/fileupload/controllers/RedirectionFeatureSpec.scala
+++ b/test/uk/gov/hmrc/fileupload/controllers/RedirectionFeatureSpec.scala
@@ -92,7 +92,7 @@ class RedirectionFeatureSpec extends UnitSpec with ScalaFutures with TestApplica
 
       status(resultF) shouldEqual MOVED_PERMANENTLY
 
-      getResultLocation(resultF) shouldEqual (OK_URL_ALLOWED + s"?errorCode:404&reason=" + errorMsg)
+      getResultLocation(resultF) shouldEqual (OK_URL_ALLOWED + s"?errorCode=404&reason=" + errorMsg)
     }
 
     "redirect on failure with complex msg error" in {
@@ -105,7 +105,7 @@ class RedirectionFeatureSpec extends UnitSpec with ScalaFutures with TestApplica
 
       status(resultF) shouldEqual MOVED_PERMANENTLY
 
-      getResultLocation(resultF) shouldEqual (OK_URL_ALLOWED + s"?errorCode:404&reason=" + errorMsg)
+      getResultLocation(resultF) shouldEqual (OK_URL_ALLOWED + s"?errorCode=404&reason=" + errorMsg)
     }
 
     "block not allowed domains" in {


### PR DESCRIPTION
The readme states that

> On error we append to the provided error-url: `s"?errorCode=$ERROR_CODE&reason=$BODY_OF_ERROR_RESPONSE".`

but a `:` is used rather than a `=` for the errorCode
