### PR TITLE
FILE-457:sbt it:test can pick up all integration tests

### DIFF
--- a/it/uk/gov/hmrc/fileupload/RepositoryISpec.scala
+++ b/it/uk/gov/hmrc/fileupload/RepositoryISpec.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.fileupload.support.IntegrationTestApplicationComponents
 import uk.gov.hmrc.fileupload.transfer.Repository
 import uk.gov.hmrc.fileupload.transfer.TransferService.{EnvelopeAvailableServiceError, EnvelopeNotFoundError}
 
-class RepositorySpec extends IntegrationTestApplicationComponents {
+class RepositoryISpec extends IntegrationTestApplicationComponents {
 
 
   "When calling the envelope check" should {

--- a/it/uk/gov/hmrc/fileupload/quarantine/RepositoryISpec.scala
+++ b/it/uk/gov/hmrc/fileupload/quarantine/RepositoryISpec.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.Future
 
-class RepositorySpec extends UnitSpec with MongoSpecSupport with TestApplicationComponents with ScalaFutures with BeforeAndAfterEach {
+class RepositoryISpec extends UnitSpec with MongoSpecSupport with TestApplicationComponents with ScalaFutures with BeforeAndAfterEach {
 
   implicit override val patienceConfig = PatienceConfig(timeout = Span(5, Seconds), interval = Span(5, Millis))
 


### PR DESCRIPTION
this issue was because of the itFilter in MicroService.
def itFilter(name: String): Boolean = name endsWith "ISpec"