### PR TITLE
Better error reporting when interacting with S3 and backend

### DIFF
--- a/app/uk/gov/hmrc/fileupload/s3/S3JavaSdkService.scala
+++ b/app/uk/gov/hmrc/fileupload/s3/S3JavaSdkService.scala
@@ -176,12 +176,7 @@ class S3JavaSdkService(configuration: com.typesafe.config.Config, metrics: Metri
               uploadTime.stop()
               metricUploadCompletedSize.inc(fileSize)
               val resultTry = Try({
-                val result = upload.waitForUploadResult()
-                if (result.getVersionId == null) {
-                  throw new Exception("The service is configured to use non-versioned S3 bucket. Bucket name $bucketName")
-                } else {
-                  result
-                }
+                upload.waitForUploadResult()
               })
               Logger.info(s"upload-s3 completed: $fileInfo with success=${resultTry.isSuccess}")
               promise.tryComplete(resultTry)

--- a/app/uk/gov/hmrc/fileupload/testonly/TestOnlyController.scala
+++ b/app/uk/gov/hmrc/fileupload/testonly/TestOnlyController.scala
@@ -47,7 +47,13 @@ class TestOnlyController(baseUrl: String, recreateCollections: () => Unit, wSCli
     val payload = Json.toJson(request.body)
 
     wSClient.url(s"$baseUrl/file-upload/envelopes").post(payload).map { response =>
-      Created(Json.obj("envelopeId" -> extractEnvelopeId(response)))
+      if (response.status >= 200 && response.status <= 299) {
+        Created(Json.obj("envelopeId" -> extractEnvelopeId(response)))
+      } else {
+        InternalServerError(
+          Json.obj("upstream_status" -> response.status, "error_message" -> response.body)
+        )
+      }
     }
   }
 


### PR DESCRIPTION
1) file-upload-frontend has few testing endpoints that talk with file-upload backend. These endpoints were ignoring errors coming from the backend (and returning HTTP200), so that we didn't know what was happening.
2) more verbose reporting when  uploading to S3 failed. Currently we just report that upload has failed and we don't give details. This change will extract and display proper exception with stacktrace.

This has been excluded from PR as it breaks integration tests:
3) file-upload requires versioned S3 buckets. Currently if by mistake you use unversioned S3 buckets you will introduce null values from Java S3 client, pass these nulls to the backend and backend will fail in suprising way. This fix ensures that S3 bucket is versioned and if not, fails gracefully
