### PR TITLE
removed CSRF bypass because no allowlist header present

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -21,11 +21,6 @@ play.application.loader = uk.gov.hmrc.fileupload.ApplicationLoader
 
 play.crypto.secret="LvK8smzDPV07QBm0mAuP`OZfjM`^PT6DYD_9IQp^rQ7^H<?QHcHi;my>aSsh8Xjh"
 
-play.filters.csrf.header.bypassHeaders {
-  X-Requested-With = "*"
-  Csrf-Token = "nocheck"
-}
-
 play.http.parser.maxDiskBuffer=100MB
 
 controllers {


### PR DESCRIPTION
The CSRF bypass header is being used without an allowlist. Have removed it in this commit to close this vulnerability.
https://jira.tools.tax.service.gov.uk/browse/PSEC-1051