### PR TITLE
Avoid setting contentLength on AWS upload since can lead to timeouts

### DIFF
--- a/app/uk/gov/hmrc/fileupload/controllers/FileUploadController.scala
+++ b/app/uk/gov/hmrc/fileupload/controllers/FileUploadController.scala
@@ -84,7 +84,7 @@ class FileUploadController @Inject()(
         case Left(_) => Future.successful(EntityTooLarge)
         case Right(formData) =>
           val allowZeroLengthFiles = constraints.flatMap(_.allowZeroLengthFiles)
-          val fileIsEmpty = formData.files.headOption.map(_.ref.size)
+          val fileIsEmpty = formData.files.headOption.map(_.ref.data.size)
 
           val failedRequirementsO =
             if formData.files.size != 1 then
@@ -118,7 +118,7 @@ class FileUploadController @Inject()(
   ): Future[Result] =
     val file = formData.files.head
     val key = createS3Key(envelopeId, fileId)
-    uploadToQuarantine(key, file.ref.inputStream, file.ref.size)
+    uploadToQuarantine(key, file.ref.data)
       .flatMap: uploadResult =>
         val fileRefId = FileRefId(uploadResult.versionId)
         commandHandler
@@ -129,7 +129,7 @@ class FileUploadController @Inject()(
               created     = now(),
               name        = file.filename,
               contentType = file.contentType.getOrElse(""),
-              length      = file.ref.size,
+              length      = file.ref.data.size,
               metadata    = metadataAsJson(formData)
             )
           .map:

--- a/app/uk/gov/hmrc/fileupload/controllers/FileUploadController.scala
+++ b/app/uk/gov/hmrc/fileupload/controllers/FileUploadController.scala
@@ -84,7 +84,7 @@ class FileUploadController @Inject()(
         case Left(_) => Future.successful(EntityTooLarge)
         case Right(formData) =>
           val allowZeroLengthFiles = constraints.flatMap(_.allowZeroLengthFiles)
-          val fileIsEmpty = formData.files.headOption.map(_.ref.data.size)
+          val fileIsEmpty = formData.files.headOption.map(_.ref.size)
 
           val failedRequirementsO =
             if formData.files.size != 1 then
@@ -129,7 +129,7 @@ class FileUploadController @Inject()(
               created     = now(),
               name        = file.filename,
               contentType = file.contentType.getOrElse(""),
-              length      = file.ref.data.size,
+              length      = file.ref.size,
               metadata    = metadataAsJson(formData)
             )
           .map:

--- a/app/uk/gov/hmrc/fileupload/controllers/FileUploadController.scala
+++ b/app/uk/gov/hmrc/fileupload/controllers/FileUploadController.scala
@@ -118,7 +118,7 @@ class FileUploadController @Inject()(
   ): Future[Result] =
     val file = formData.files.head
     val key = createS3Key(envelopeId, fileId)
-    uploadToQuarantine(key, file.ref.data)
+    uploadToQuarantine(key, file.ref.data, file.ref.md5Hash)
       .flatMap: uploadResult =>
         val fileRefId = FileRefId(uploadResult.versionId)
         commandHandler

--- a/app/uk/gov/hmrc/fileupload/s3/InMemoryMultipartFileHandler.scala
+++ b/app/uk/gov/hmrc/fileupload/s3/InMemoryMultipartFileHandler.scala
@@ -28,7 +28,9 @@ import scala.concurrent.ExecutionContext
 object InMemoryMultipartFileHandler:
   type InMemoryMultiPartBodyParser = () => BodyParser[MultipartFormData[FileCachedInMemory]]
 
-  case class FileCachedInMemory(data: ByteString)
+  case class FileCachedInMemory(data: ByteString):
+    def md5Hash: String =
+      Md5Hash.md5Hash(data)
 
   def cacheFileInMemory(using ExecutionContext): FilePartHandler[FileCachedInMemory] =
     case FileInfo(partName, filename, contentType, dispositionType) =>

--- a/app/uk/gov/hmrc/fileupload/s3/InMemoryMultipartFileHandler.scala
+++ b/app/uk/gov/hmrc/fileupload/s3/InMemoryMultipartFileHandler.scala
@@ -16,8 +16,6 @@
 
 package uk.gov.hmrc.fileupload.s3
 
-import java.io.InputStream
-
 import org.apache.pekko.stream.scaladsl.Sink
 import org.apache.pekko.util.ByteString
 import play.api.libs.streams.Accumulator
@@ -30,12 +28,7 @@ import scala.concurrent.ExecutionContext
 object InMemoryMultipartFileHandler:
   type InMemoryMultiPartBodyParser = () => BodyParser[MultipartFormData[FileCachedInMemory]]
 
-  case class FileCachedInMemory(data: ByteString):
-    def size: Int =
-      data.size
-
-    def inputStream: InputStream =
-      data.iterator.asInputStream
+  case class FileCachedInMemory(data: ByteString)
 
   def cacheFileInMemory(using ExecutionContext): FilePartHandler[FileCachedInMemory] =
     case FileInfo(partName, filename, contentType, dispositionType) =>

--- a/app/uk/gov/hmrc/fileupload/s3/InMemoryMultipartFileHandler.scala
+++ b/app/uk/gov/hmrc/fileupload/s3/InMemoryMultipartFileHandler.scala
@@ -29,7 +29,10 @@ object InMemoryMultipartFileHandler:
   type InMemoryMultiPartBodyParser = () => BodyParser[MultipartFormData[FileCachedInMemory]]
 
   case class FileCachedInMemory(data: ByteString):
-    def md5Hash: String =
+    def size: Int =
+      data.size
+
+    lazy val md5Hash: String =
       Md5Hash.md5Hash(data)
 
   def cacheFileInMemory(using ExecutionContext): FilePartHandler[FileCachedInMemory] =

--- a/app/uk/gov/hmrc/fileupload/s3/Md5Hash.scala
+++ b/app/uk/gov/hmrc/fileupload/s3/Md5Hash.scala
@@ -30,3 +30,8 @@ object Md5Hash:
     Sink
       .foreach[ByteString](bs => md.update(bs.toArray))
       .mapMaterializedValue(_.map(_ => Base64.getEncoder.encodeToString(md.digest())))
+
+  def md5Hash(data: ByteString): String =
+    val md = MessageDigest.getInstance("MD5")
+    md.update(data.toArray)
+    Base64.getEncoder.encodeToString(md.digest())

--- a/app/uk/gov/hmrc/fileupload/s3/S3Service.scala
+++ b/app/uk/gov/hmrc/fileupload/s3/S3Service.scala
@@ -27,7 +27,6 @@ import uk.gov.hmrc.fileupload.{EnvelopeId, FileId}
 import uk.gov.hmrc.fileupload.quarantine.FileData
 import uk.gov.hmrc.fileupload.s3.S3Service.{DeleteFileFromQuarantineBucket, DownloadFromBucket, StreamResult, UploadToQuarantine}
 
-import java.io.InputStream
 import java.net.URL
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
@@ -42,10 +41,10 @@ trait S3Service:
 
   def retrieveFileFromQuarantine(key: S3KeyName, versionId: String)(using ExecutionContext): Future[Option[FileData]]
 
-  def upload(bucketName: String, key: S3KeyName, file: InputStream, fileSize: Int): Future[PutObjectResponse]
+  def upload(bucketName: String, key: S3KeyName, file: ByteString): Future[PutObjectResponse]
 
   def uploadToQuarantine: UploadToQuarantine =
-    upload(awsConfig.quarantineBucketName, _, _, _)
+    upload(awsConfig.quarantineBucketName, _, _)
 
   def downloadFromTransient: DownloadFromBucket =
     download(awsConfig.transientBucketName, _)
@@ -88,7 +87,7 @@ end S3Service
 object S3Service:
   type StreamResult = Source[ByteString, Future[IOResult]]
 
-  type UploadToQuarantine = (S3KeyName, InputStream, Int) => Future[PutObjectResponse]
+  type UploadToQuarantine = (S3KeyName, ByteString) => Future[PutObjectResponse]
 
   type DownloadFromBucket = S3KeyName => Option[StreamWithMetadata]
 

--- a/app/uk/gov/hmrc/fileupload/s3/S3Service.scala
+++ b/app/uk/gov/hmrc/fileupload/s3/S3Service.scala
@@ -41,10 +41,10 @@ trait S3Service:
 
   def retrieveFileFromQuarantine(key: S3KeyName, versionId: String)(using ExecutionContext): Future[Option[FileData]]
 
-  def upload(bucketName: String, key: S3KeyName, file: ByteString): Future[PutObjectResponse]
+  def upload(bucketName: String, key: S3KeyName, file: ByteString, contentMd5: String): Future[PutObjectResponse]
 
   def uploadToQuarantine: UploadToQuarantine =
-    upload(awsConfig.quarantineBucketName, _, _)
+    upload(awsConfig.quarantineBucketName, _, _, _)
 
   def downloadFromTransient: DownloadFromBucket =
     download(awsConfig.transientBucketName, _)
@@ -87,7 +87,7 @@ end S3Service
 object S3Service:
   type StreamResult = Source[ByteString, Future[IOResult]]
 
-  type UploadToQuarantine = (S3KeyName, ByteString) => Future[PutObjectResponse]
+  type UploadToQuarantine = (S3KeyName, ByteString, String) => Future[PutObjectResponse]
 
   type DownloadFromBucket = S3KeyName => Option[StreamWithMetadata]
 

--- a/app/uk/gov/hmrc/fileupload/testonly/S3TestController.scala
+++ b/app/uk/gov/hmrc/fileupload/testonly/S3TestController.scala
@@ -63,7 +63,7 @@ trait S3TestController(using ExecutionContext):
         val numberOfFiles = req.body.files.size
         if numberOfFiles == 1 then
           val uploadedFile = req.body.files.head.ref
-          s3Service.upload(bucketName, S3KeyName(fileName), uploadedFile.inputStream, uploadedFile.size)
+          s3Service.upload(bucketName, S3KeyName(fileName), uploadedFile.data)
             .map(ur => Ok(s"key $fileName, version: ${ur.versionId}"))
         else
           Future.successful(BadRequest("Expected exactly one file to be attached"))

--- a/app/uk/gov/hmrc/fileupload/testonly/S3TestController.scala
+++ b/app/uk/gov/hmrc/fileupload/testonly/S3TestController.scala
@@ -63,7 +63,7 @@ trait S3TestController(using ExecutionContext):
         val numberOfFiles = req.body.files.size
         if numberOfFiles == 1 then
           val uploadedFile = req.body.files.head.ref
-          s3Service.upload(bucketName, S3KeyName(fileName), uploadedFile.data)
+          s3Service.upload(bucketName, S3KeyName(fileName), uploadedFile.data, uploadedFile.md5Hash)
             .map(ur => Ok(s"key $fileName, version: ${ur.versionId}"))
         else
           Future.successful(BadRequest("Expected exactly one file to be attached"))

--- a/build.sbt
+++ b/build.sbt
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-import play.routes.compiler.InjectedRoutesGenerator
 import play.sbt.PlayImport.PlayKeys
-import play.sbt.routes.RoutesKeys.routesGenerator
 import uk.gov.hmrc.DefaultBuildSettings
 
 ThisBuild / majorVersion := 1

--- a/it/test/uk/gov/hmrc/fileupload/support/FakeFileUploadBackend.scala
+++ b/it/test/uk/gov/hmrc/fileupload/support/FakeFileUploadBackend.scala
@@ -213,10 +213,9 @@ class InMemoryS3Service(
     Future.successful(getBucket(bucketName).get(key.value).map(_.toFileData))
   }
 
-  override def upload(bucketName: String, key: S3KeyName, file: InputStream, fileSize: Int): Future[PutObjectResponse] = {
-    updateBucket(bucketName)(_ + (key.value -> S3File(scala.io.Source.fromInputStream(file).mkString, fileSize)))
+  override def upload(bucketName: String, key: S3KeyName, file: ByteString, contentMd5: String): Future[PutObjectResponse] =
+    updateBucket(bucketName)(_ + (key.value -> S3File(file.decodeString("UTF-8"), file.size)))
     Future.successful(PutObjectResponse.builder.build())
-  }
 
   override def listFilesInBucket(bucketName: String): Source[Seq[S3Object], NotUsed] =
     Source.single(

--- a/test/uk/gov/hmrc/fileupload/controllers/FileUploadControllerSpec.scala
+++ b/test/uk/gov/hmrc/fileupload/controllers/FileUploadControllerSpec.scala
@@ -62,7 +62,7 @@ class FileUploadControllerSpec
         Future.successful(Right(NotifySuccess))
     }
     val fakeCurrentTime = () => 10L
-    val uploadToQuarantine: UploadToQuarantine = (_, _) => Future.successful(PutObjectResponse.builder().build())
+    val uploadToQuarantine: UploadToQuarantine = (_, _, _) => Future.successful(PutObjectResponse.builder().build())
     val createS3Key: (EnvelopeId, FileId) => S3KeyName = (_, _) => S3KeyName("key")
     val configuration = Configuration.from(Map.empty)
     val loggerHelper = new LoggerHelper {

--- a/test/uk/gov/hmrc/fileupload/controllers/FileUploadControllerSpec.scala
+++ b/test/uk/gov/hmrc/fileupload/controllers/FileUploadControllerSpec.scala
@@ -62,8 +62,8 @@ class FileUploadControllerSpec
         Future.successful(Right(NotifySuccess))
     }
     val fakeCurrentTime = () => 10L
-    val uploadToQuarantine: UploadToQuarantine = (_,_,_) => Future.successful(PutObjectResponse.builder().build())
-    val createS3Key: (EnvelopeId, FileId) => S3KeyName = (_,_) => S3KeyName("key")
+    val uploadToQuarantine: UploadToQuarantine = (_, _) => Future.successful(PutObjectResponse.builder().build())
+    val createS3Key: (EnvelopeId, FileId) => S3KeyName = (_, _) => S3KeyName("key")
     val configuration = Configuration.from(Map.empty)
     val loggerHelper = new LoggerHelper {
       override def getLoggerValues(formData: MultipartFormData.FilePart[FileCachedInMemory], request: Request[_]): LoggerValues =


### PR DESCRIPTION
Replacing the content length with md5 hash to ensure no corruption during the upload